### PR TITLE
Implement onSDKReady callback

### DIFF
--- a/src/AnalyticsProvider.tsx
+++ b/src/AnalyticsProvider.tsx
@@ -1,5 +1,5 @@
 // src/components/AnalyticsProvider.tsx
-import React, { useEffect } from "react";
+import React, {useEffect} from "react";
 import { initSDK } from "./init";
 import * as analytics from "./tracker";
 
@@ -20,6 +20,7 @@ export const AnalyticsProvider = ({
                                       children,
                                       autoPageTrack = true
                                   }: AnalyticsProviderProps) => {
+
     useEffect(() => {
         initSDK({ clientId, applicationId , orgId, eventStreamId });
         if (autoPageTrack) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,5 @@ export { AnalyticsProvider } from "./AnalyticsProvider";
 export { getProfileId } from "./init";
 export { getAppId } from "./init";
 export { getBaseUrl } from "./init";
+export { onSDKReady } from "./init";
 


### PR DESCRIPTION
This callback make sure the SDK is initialized before calling the functions provided by the SDK like getProfileId()